### PR TITLE
Add support to Jed context

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function messageIsExcluded(msg, extensions) {
 }
 
 module.exports = function(source) {
-  var options = loaderUtils.getOptions(this.query);
+  var options = loaderUtils.getOptions(this);
   var catalog = gettextParser.po.parse(source, 'UTF-8');
 
   this.cacheable();

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function messageIsExcluded(msg, extensions) {
 }
 
 module.exports = function(source) {
-  var options = loaderUtils.parseQuery(this.query);
+  var options = loaderUtils.getOptions(this.query);
   var catalog = gettextParser.po.parse(source, 'UTF-8');
 
   this.cacheable();

--- a/index.js
+++ b/index.js
@@ -72,7 +72,9 @@ module.exports = function(source) {
 
   if (options.raw) {
     return rv;
+  } else if (options.json) {
+      return JSON.stringify(rv);
   }
 
   return 'module.exports = ' + JSON.stringify(rv) + ';';
-}
+};

--- a/index.js
+++ b/index.js
@@ -37,16 +37,32 @@ module.exports = function(source) {
   this.cacheable();
 
   var rv = {};
-  for (var msgid in catalog.translations['']) {
-    if (msgid === '') {
+
+  for (var context in catalog.translations) {
+    if (!catalog.translations.hasOwnProperty(context)) {
       continue;
     }
-    var msg = catalog.translations[''][msgid];
-    if (!isEmptyMessage(msg) &&
-        !messageIsExcluded(msg, options.referenceExtensions)) {
-      rv[msgid] = msg.msgstr;
+
+    for (var msgid in catalog.translations[context]) {
+      if (msgid === '') {
+        continue;
+      }
+
+      var msg = catalog.translations[context][msgid];
+
+      if (!isEmptyMessage(msg) &&
+          !messageIsExcluded(msg, options.referenceExtensions)) {
+        if (context !== '' && options.addJedContext) {
+          rv[context + '\u0004' + msgid] = msg.msgstr;
+        } else {
+          rv[msgid] = msg.msgstr;
+        }
+
+      }
     }
+
   }
+
 
   rv[''] = {
     domain: options.domain || 'messages',

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "main": "index.js",
   "dependencies": {
-    "loader-utils": "^0.2.5"
+    "loader-utils": "^1.1.0"
   }
 }


### PR DESCRIPTION
Add an optional `addJedContext` option, which if is true, add the context (if any) to the JSON keys in the Jed way, prefixing the key with the context and a unicode \u0004 as the delimiter.

@getsentry/infrastructure 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/po-catalog-loader/1)

<!-- Reviewable:end -->
